### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "vows": "0.7.x"
   },
   "author": "Marcel Klehr <mklehr@gmx.net>",
-  "license": [{"type": "MIT", "url": "http://opensource.org/licenses/MIT"}],
+  "license": "MIT",
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
